### PR TITLE
Add Proxmox LXC support with non-privileged ports

### DIFF
--- a/docker-compose.proxmox.yml
+++ b/docker-compose.proxmox.yml
@@ -1,0 +1,19 @@
+# Docker Compose override for Proxmox LXC containers
+# This file changes privileged ports (80, 443) to non-privileged ports (8080, 8443)
+#
+# Usage: docker compose -f docker-compose.yml -f docker-compose.proxmox.yml up -d
+# Or set COMPOSE_FILE environment variable:
+#   export COMPOSE_FILE=docker-compose.yml:docker-compose.proxmox.yml
+
+version: "3.8"
+
+services:
+  # Nginx reverse proxy - using non-privileged ports for Proxmox LXC
+  nginx:
+    ports:
+      - "8080:80" # HTTP on 8080 instead of 80
+      - "8443:443" # HTTPS on 8443 instead of 443
+
+
+
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -80,6 +80,8 @@ services:
     # Note: container_name removed to allow scaling
 
   # Nginx reverse proxy
+  # Note: For Proxmox LXC containers, use docker-compose.proxmox.yml override
+  # to use non-privileged ports (8080/8443) instead of 80/443
   nginx:
     image: nginx:alpine
     container_name: pulsevault-nginx


### PR DESCRIPTION
- Add docker-compose.proxmox.yml override for LXC containers
- Maps ports 80/443 to 8080/8443 to avoid sysctl permission errors
- Update docker-compose.yml with Proxmox usage notes
- Fixes issue with privileged port binding in Proxmox LXC containers