### PR TITLE
Fix: Use X-Forwarded-Proto for Location Header Rewrite in Nginx

### DIFF
--- a/nginx/conf.d/pulsevault-locations.conf
+++ b/nginx/conf.d/pulsevault-locations.conf
@@ -38,16 +38,15 @@ location ~ ^/uploads(/.*)?$ {
     
     # Preserve Location header from backend (critical for TUS)
     # Rewrite Location header to use external URL
-    # For production (HTTPS on standard port): use $http_host which includes port from request
-    # For development (HTTP on 8080): $http_host will include :8080
-    # Proxmox handles SSL termination, so $scheme will be http internally but Location should match client's scheme
-    proxy_redirect http://pulsevault_backend/uploads/ $scheme://$http_host/uploads/;
-    proxy_redirect http://pulsevault:3000/uploads/ $scheme://$http_host/uploads/;
-    proxy_redirect http://localhost/uploads/ $scheme://$http_host/uploads/;
-    proxy_redirect http://127.0.0.1:3000/uploads/ $scheme://$http_host/uploads/;
+    # Use $external_scheme (defined in nginx.conf) which uses X-Forwarded-Proto if available
+    # This ensures HTTPS clients get HTTPS Location headers even when nginx sees HTTP internally
+    proxy_redirect http://pulsevault_backend/uploads/ $external_scheme://$http_host/uploads/;
+    proxy_redirect http://pulsevault:3000/uploads/ $external_scheme://$http_host/uploads/;
+    proxy_redirect http://localhost/uploads/ $external_scheme://$http_host/uploads/;
+    proxy_redirect http://127.0.0.1:3000/uploads/ $external_scheme://$http_host/uploads/;
     # Handle Location headers without port (from backend) - use $http_host to preserve client's port
-    proxy_redirect http://$host/uploads/ $scheme://$http_host/uploads/;
-    proxy_redirect https://$host/uploads/ $scheme://$http_host/uploads/;
+    proxy_redirect http://$host/uploads/ $external_scheme://$http_host/uploads/;
+    proxy_redirect https://$host/uploads/ $external_scheme://$http_host/uploads/;
     proxy_pass_header Location;
     
     # CORS headers for mobile app

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -11,6 +11,13 @@ events {
 http {
     include /etc/nginx/mime.types;
     default_type application/octet-stream;
+    
+    # Map to determine external scheme (for SSL termination behind Proxmox)
+    # Use X-Forwarded-Proto if available, otherwise use $scheme
+    map $http_x_forwarded_proto $external_scheme {
+        default $http_x_forwarded_proto;
+        '' $scheme;
+    }
 
     # Logging format with more details
     log_format main '$remote_addr - $remote_user [$time_local] "$request" '


### PR DESCRIPTION
## Problem

When Proxmox handles SSL termination and forwards requests to nginx as HTTP, nginx was rewriting Location headers using `$scheme` (which is `http` internally). This caused:

- Client connects via HTTPS: `https://pulse-vault.opensource.mieweb.org`
- Nginx sees HTTP internally (after Proxmox SSL termination)
- Location header rewritten as: `http://pulse-vault.opensource.mieweb.org/uploads/...`
- Mobile app receives HTTP Location header but needs HTTPS
- Subsequent PATCH requests fail with "Network request failed"

## Solution

Added a `map` directive in nginx to use `X-Forwarded-Proto` header (set by Proxmox) when available, falling back to `$scheme` for development environments. This ensures Location headers match the client's original protocol.

## Changes

- **`nginx/nginx.conf`**:
  - Added `map $http_x_forwarded_proto $external_scheme` directive at http level
  - Uses `X-Forwarded-Proto` if present, otherwise falls back to `$scheme`

- **`nginx/conf.d/pulsevault-locations.conf`**:
  - Updated all `proxy_redirect` rules to use `$external_scheme` instead of `$scheme`
  - Ensures Location headers use HTTPS when client connects via HTTPS

## Technical Details

The `map` directive creates a variable `$external_scheme` that:
- Uses `$http_x_forwarded_proto` when Proxmox sets it (production)
- Falls back to `$scheme` for local development (where SSL termination doesn't occur)

This allows the same nginx configuration to work correctly in both:
- **Production**: Proxmox SSL termination → nginx sees HTTP but `X-Forwarded-Proto: https` → Location uses HTTPS
- **Development**: Direct HTTP connection → `$scheme` is `http` → Location uses HTTP

## Testing

- ✅ Tested in production environment with Proxmox
- ✅ Verified Location headers now use HTTPS when client connects via HTTPS
- ✅ Confirmed backward compatibility with development environment
- ✅ TUS upload PATCH requests succeed with correct protocol

## Related

This fix works in conjunction with the client-side changes in the main `pulse` repo (see `fix/upload-https-location-header` branch) which provides an additional safety net to upgrade HTTP Location URLs to HTTPS.

