### PR TITLE
Center store badges on upload card in mobile view

### DIFF
--- a/frontend/components/store-badges.tsx
+++ b/frontend/components/store-badges.tsx
@@ -43,7 +43,7 @@ export function StoreBadges({
         </p>
       )}
       <div
-        className={`flex flex-wrap items-center gap-3 ${
+        className={`flex flex-wrap items-center justify-center gap-3 ${
           layout === "stack" ? "flex-col sm:flex-row" : "flex-row"
         }`}
       >


### PR DESCRIPTION
Add justify-center to StoreBadges flex container so App Store and Google Play badges are centered on mobile.