### PR TITLE
PR: Configure-destination deeplink & finalize with client draftId

### DIFF
--- a/frontend/app/upload/upload-client.tsx
+++ b/frontend/app/upload/upload-client.tsx
@@ -3,6 +3,7 @@
 import { Session } from "@/lib/auth";
 import { UploadQRCard } from "@/components/upload-qr-card";
 import { UploadMobileOpenCard } from "@/components/upload-mobile-open-card";
+import { ConfigureAppCard } from "@/components/configure-app-card";
 import { useEffect, useState } from "react";
 
 function isMobileDevice(): boolean {
@@ -37,7 +38,9 @@ export default function UploadClient({ session }: {
           </p>
         </div>
         
-        <div className="w-full max-w-md mx-auto">
+        <div className="w-full max-w-md mx-auto space-y-6">
+          {/* Setup your app: add this vault as upload destination (30-day token) */}
+          <ConfigureAppCard />
           {isMobile === null ? (
             <div className="py-8 text-center text-muted-foreground text-sm">
               Loading...

--- a/frontend/app/upload/upload-client.tsx
+++ b/frontend/app/upload/upload-client.tsx
@@ -23,7 +23,7 @@ export default function UploadClient({ session }: {
 
   return (
     <div className="min-h-screen bg-background">
-      <div className="max-w-2xl mx-auto px-4 sm:px-6 lg:px-8 py-4 sm:py-6 lg:py-8">
+      <div className="max-w-2xl md:max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 py-4 sm:py-6 lg:py-8">
         {/* Header */}
         <div className="mb-6 sm:mb-8">
           <h1 className="text-xl sm:text-2xl lg:text-3xl font-bold text-card-foreground">Upload from Mobile</h1>
@@ -37,19 +37,23 @@ export default function UploadClient({ session }: {
             )}
           </p>
         </div>
-        
-        <div className="w-full max-w-md mx-auto space-y-6">
-          {/* Setup your app: add this vault as upload destination (30-day token) */}
-          <ConfigureAppCard />
-          {isMobile === null ? (
-            <div className="py-8 text-center text-muted-foreground text-sm">
-              Loading...
-            </div>
-          ) : isMobile ? (
-            <UploadMobileOpenCard />
-          ) : (
-            <UploadQRCard />
-          )}
+
+        {/* Desktop: side by side | Mobile: stacked */}
+        <div className="flex flex-col gap-6 md:flex-row md:gap-8 md:items-stretch">
+          <div className="w-full md:min-w-0 md:flex-1">
+            <ConfigureAppCard />
+          </div>
+          <div className="w-full md:min-w-0 md:flex-1">
+            {isMobile === null ? (
+              <div className="py-8 text-center text-muted-foreground text-sm rounded-lg border border-border bg-card">
+                Loading...
+              </div>
+            ) : isMobile ? (
+              <UploadMobileOpenCard />
+            ) : (
+              <UploadQRCard />
+            )}
+          </div>
         </div>
       </div>
     </div>

--- a/frontend/components/configure-app-card.tsx
+++ b/frontend/components/configure-app-card.tsx
@@ -1,0 +1,128 @@
+"use client";
+
+import { useState } from "react";
+import { QRCodeSVG } from "qrcode.react";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { generateConfigureAppDeeplink } from "@/lib/actions/video-actions";
+import { Loader2, Settings } from "lucide-react";
+
+/**
+ * Setup your app: QR + Configure app button.
+ * Generates a long-lived destination token (no draftId). Pulse app adds this vault
+ * as an upload destination; user can then choose it when uploading from camera drafts.
+ */
+export function ConfigureAppCard() {
+  const [data, setData] = useState<{
+    deeplink: string;
+    server: string;
+    expiresAt: string;
+    expiresIn: number;
+    qrData: string;
+  } | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleGenerate = async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const result = await generateConfigureAppDeeplink();
+      setData(result);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to generate setup link");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleConfigureApp = () => {
+    if (data?.deeplink) {
+      window.location.href = data.deeplink;
+    }
+  };
+
+  return (
+    <Card className="w-full">
+      <CardHeader className="pb-3">
+        <CardTitle className="text-lg flex items-center gap-2">
+          <Settings className="h-5 w-5" />
+          Setup your app
+        </CardTitle>
+        <CardDescription className="text-xs">
+          Give Pulse access to upload to this vault for 30 days. Scan the QR or tap Configure app on your phone.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="flex flex-col items-center gap-3">
+        {error && (
+          <div className="w-full p-2 rounded-md bg-destructive/10 text-destructive text-xs">
+            {error}
+          </div>
+        )}
+        {data ? (
+          <div className="flex flex-col items-center gap-3 w-full">
+            <div className="p-2 bg-white rounded-lg border-2 border-border">
+              <QRCodeSVG
+                value={data.qrData}
+                size={180}
+                level="M"
+                includeMargin={true}
+              />
+            </div>
+            <div className="w-full space-y-1.5 text-xs">
+              <div className="flex justify-between">
+                <span className="text-muted-foreground">Expires:</span>
+                <span className="text-right">{new Date(data.expiresAt).toLocaleString()}</span>
+              </div>
+              <div className="flex justify-between">
+                <span className="text-muted-foreground">Valid for:</span>
+                <span>{Math.floor(data.expiresIn / 86400)} days</span>
+              </div>
+            </div>
+          </div>
+        ) : (
+          <div className="py-6 text-center text-muted-foreground text-sm">
+            Generate a setup link to add this vault as an upload destination in Pulse.
+          </div>
+        )}
+      </CardContent>
+      <CardFooter className="flex flex-col gap-2 pt-3">
+        <Button
+          onClick={data ? handleConfigureApp : handleGenerate}
+          disabled={loading}
+          className="w-full"
+          size="sm"
+        >
+          {loading ? (
+            <>
+              <Loader2 className="mr-2 h-3 w-3 animate-spin" />
+              Generating...
+            </>
+          ) : data ? (
+            "Configure app"
+          ) : (
+            "Generate setup link"
+          )}
+        </Button>
+        {data && (
+          <Button
+            variant="outline"
+            onClick={handleGenerate}
+            disabled={loading}
+            className="w-full"
+            size="sm"
+          >
+            New setup link
+          </Button>
+        )}
+      </CardFooter>
+    </Card>
+  );
+}

--- a/frontend/lib/actions/video-actions.ts
+++ b/frontend/lib/actions/video-actions.ts
@@ -56,6 +56,40 @@ export type QRCodeData = {
 };
 
 /**
+ * Generate "Configure app" deeplink - long-lived destination token (no draftId).
+ * Pulse app adds this server as an upload destination; draftId is sent by app at upload time.
+ * Token valid 30 days by default.
+ */
+export async function generateConfigureAppDeeplink() {
+  const session = await getSession();
+  if (!session?.user) {
+    unauthorized();
+  }
+
+  const backendUrl = process.env.BACKEND_URL || "http://pulsevault:3000";
+  const serverUrl = process.env.BETTER_AUTH_URL || "http://localhost:8080";
+  const expiresIn = 30 * 24 * 60 * 60; // 30 days in seconds
+
+  const response = await fetch(
+    `${backendUrl}/qr/configure-destination?userId=${session.user.id}&server=${encodeURIComponent(serverUrl)}&expiresIn=${expiresIn}`,
+    { method: "GET" }
+  );
+
+  if (!response.ok) {
+    throw new Error("Failed to generate configure app link");
+  }
+
+  const data = await response.json();
+  return {
+    deeplink: data.deeplink,
+    server: data.server,
+    expiresAt: data.expiresAt,
+    expiresIn: data.expiresIn,
+    qrData: data.qrData,
+  };
+}
+
+/**
  * Get all videos (for feed) - fetched directly from backend storage
  * No database entries needed - all data comes from storage metadata
  */

--- a/pulsevault/routes/qr.js
+++ b/pulsevault/routes/qr.js
@@ -92,6 +92,75 @@ module.exports = async function (fastify, opts) {
    * Generate QR code data for deeplink with signed token
    * Returns the deeplink URL that can be encoded as QR code
    */
+  /**
+   * Generate deeplink for "configure destination" (setup app) - long-lived token, no draftId.
+   * App will send draftId at finalize when using this token.
+   * Default expiry 30 days.
+   */
+  fastify.get('/qr/configure-destination', {
+    schema: {
+      querystring: {
+        type: 'object',
+        properties: {
+          server: { type: 'string' },
+          userId: { type: 'string' },
+          organizationId: { type: 'string' },
+          expiresIn: { type: 'number', default: 2592000 } // 30 days default
+        }
+      }
+    }
+  }, async (request, reply) => {
+    const {
+      server,
+      userId = 'anonymous',
+      organizationId,
+      expiresIn = 2592000
+    } = request.query
+
+    // Get server URL from query or request
+    let serverUrl = server
+    if (!serverUrl) {
+      const protocol = request.headers['x-forwarded-proto'] || (request.protocol || 'http')
+      const host = request.headers.host || `${fastify.config.host}:${fastify.config.port}`
+      serverUrl = `${protocol}://${host}`
+    }
+    if (serverUrl && !serverUrl.includes('://')) {
+      serverUrl = `http://${serverUrl}`
+    }
+    try {
+      const parsed = new URL(serverUrl)
+      serverUrl = `${parsed.protocol}//${parsed.host}`
+    } catch (e) {
+      if (!serverUrl.includes('://')) serverUrl = `http://${serverUrl}`
+    }
+
+    const tokenData = generateUploadToken(serverUrl, {
+      userId,
+      organizationId,
+      draftId: null, // destination token: no draftId; app sends at finalize
+      expiresIn: parseInt(expiresIn, 10)
+    })
+
+    const params = new URLSearchParams({
+      mode: 'configure_destination',
+      server: serverUrl,
+      token: tokenData.token
+    })
+    const deeplinkUrl = `pulsecam://?${params.toString()}`
+
+    return {
+      deeplink: deeplinkUrl,
+      server: serverUrl,
+      token: tokenData.token,
+      expiresAt: tokenData.expiresAt,
+      expiresIn: tokenData.expiresIn,
+      tokenId: tokenData.tokenId,
+      userId,
+      organizationId: organizationId || null,
+      qrData: deeplinkUrl
+    }
+  })
+
   fastify.get('/qr/deeplink', {
     schema: {
       querystring: {

--- a/pulsevault/routes/uploads.js
+++ b/pulsevault/routes/uploads.js
@@ -78,6 +78,9 @@ module.exports = async function (fastify, opts) {
     }
   }
 
+  // UUID v4 format check for client-supplied draftId
+  const isUUIDv4 = (s) => typeof s === 'string' && /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(s)
+
   fastify.post('/uploads/finalize', {
     schema: {
       body: {
@@ -88,12 +91,13 @@ module.exports = async function (fastify, opts) {
           filename: { type: 'string' },
           userId: { type: 'string' },
           uploadToken: { type: 'string' },
+          draftId: { type: 'string' },
           metadata: { type: 'object' }
         }
       }
     }
   }, async (request, reply) => {
-    const { uploadId, filename, userId, uploadToken, metadata = {} } = request.body
+    const { uploadId, filename, userId, uploadToken, draftId: bodyDraftId, metadata = {} } = request.body
     
     // Get token from body or header (header takes precedence)
     const token = uploadToken || request.headers['x-upload-token']
@@ -124,8 +128,21 @@ module.exports = async function (fastify, opts) {
       fastify.log.warn({ uploadId }, 'Upload finalized without token (token requirement disabled)')
     }
     
-    // ENFORCE: Require draftId in token payload (all uploads must have a draft)
-    if (!tokenPayload?.draftId) {
+    // draftId: from token (per-draft QR) or from body (destination token - app sends draftId)
+    let draftId = tokenPayload?.draftId
+    if (!draftId && tokenPayload) {
+      if (bodyDraftId && isUUIDv4(bodyDraftId)) {
+        draftId = bodyDraftId
+        fastify.log.info({ uploadId, draftId }, 'Using client-supplied draftId (destination token)')
+      } else {
+        fastify.log.warn({ uploadId }, 'Upload rejected: destination token requires draftId in body')
+        return reply.code(400).send({
+          error: 'Draft ID required',
+          reason: 'Please send draftId in the request body when using a destination token.'
+        })
+      }
+    }
+    if (!draftId) {
       fastify.log.warn({ uploadId, hasToken: !!tokenPayload }, 'Upload rejected: draftId required')
       return reply.code(400).send({
         error: 'Draft ID required',
@@ -133,20 +150,18 @@ module.exports = async function (fastify, opts) {
       })
     }
     
-    // Use userId from token (required since draftId is required)
-    const finalUserId = tokenPayload.userId
+    // Use userId from token
+    const finalUserId = tokenPayload?.userId
     if (!finalUserId) {
-      fastify.log.warn({ uploadId, tokenId: tokenPayload.tokenId }, 'Upload rejected: userId missing in token')
+      fastify.log.warn({ uploadId, tokenId: tokenPayload?.tokenId }, 'Upload rejected: userId missing in token')
       return reply.code(400).send({
         error: 'User ID required',
         reason: 'Token must include userId. Please scan a valid QR code.'
       })
     }
     
-    const organizationId = tokenPayload.organizationId || null
+    const organizationId = tokenPayload?.organizationId || null
 
-    // Use draftId from token as videoId (required)
-    const draftId = tokenPayload.draftId
     const videoId = draftId
     
     fastify.log.info({ draftId, videoId, userId: finalUserId }, 'Using draftId as videoId')


### PR DESCRIPTION
## Summary closes #46

Adds a **"Setup your app"** flow so Pulse can add a vault as an upload destination once (long-lived token), and supports uploads where the **draft ID is supplied by the app** at finalize time instead of being in the token.

Enables the configurable-upload-destinations feature: one Pulse app can upload to multiple Pulse Vaults; users add vaults as destinations and choose one at upload time (see Pulse repo issue/PR for the app-side changes).

## Changes

### Backend

- **`GET /qr/configure-destination`** (new)  
  - Query: `server`, `userId`, optional `organizationId`, optional `expiresIn` (default 30 days).  
  - Returns a signed upload token **without** `draftId` and a deeplink:  
    `pulsecam://?mode=configure_destination&server=...&token=...`  
  - Used by the Pulse app to add this vault as a saved destination.

- **`POST /uploads/finalize`** (updated)  
  - Request body may include **`draftId`**.  
  - When the token has **no** `draftId` (destination token), `draftId` is **required** in the body; it is validated as UUID v4 and used as `videoId`.  
  - When the token has `draftId` (per-draft QR), behavior is unchanged (draftId from token).

### Frontend

- **`generateConfigureAppDeeplink()`** in `lib/actions/video-actions.ts`  
  - Calls backend `/qr/configure-destination` and returns deeplink + QR payload.

- **`ConfigureAppCard`** (new component)  
  - "Setup your app" card: description, "Generate setup link" → shows QR and "Configure app" button (opens deeplink).  
  - Optional "New setup link" to regenerate.

- **Upload page**  
  - Renders `ConfigureAppCard` above the existing per-draft QR / "Open in Pulse" cards.

## Testing

- [x] `GET /qr/configure-destination?userId=u1&server=http://localhost:8080` returns 200; response includes `deeplink` with `mode=configure_destination` and a token with no `draftId` in payload.
- [x] Finalize with a destination token (no draftId in token) + `draftId` in body → 200; video stored under that draftId.
- [x] Finalize with destination token and no `draftId` in body → 400.
- [x] Upload page shows "Setup your app" card; generate link shows QR; "Configure app" opens the pulsecam deeplink.

## Related

- Pulse app PR (feature/upload-destinations): handles `configure_destination` deeplink, destinations storage, destination picker on upload screen, and sends `draftId` in finalize when using a saved destination.
