### PR TITLE
feat: add duration parameter for QR code generation and local dev setup

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,222 @@
+services:
+  # ── Databases ──────────────────────────────────────────────────────────────
+
+  postgres:
+    image: postgres:16-alpine
+    container_name: pulsevault-postgres
+    restart: unless-stopped
+    ports:
+      - "5432:5432"
+    environment:
+      POSTGRES_USER: pulsevault
+      POSTGRES_PASSWORD: pulsevault
+      POSTGRES_DB: pulsevault
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U pulsevault"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  redis:
+    image: redis:7-alpine
+    container_name: pulsevault-redis
+    restart: unless-stopped
+    ports:
+      - "6379:6379"
+    volumes:
+      - redis-data:/data
+    command: redis-server --appendonly yes
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 3s
+      retries: 3
+
+  # ── Backend ─────────────────────────────────────────────────────────────────
+
+  pulsevault:
+    build:
+      context: ./pulsevault
+      dockerfile: Dockerfile
+    container_name: pulsevault-backend
+    restart: unless-stopped
+    ports:
+      - "3000:3000"
+    environment:
+      NODE_ENV: development
+      PORT: 3000
+      HOST: 0.0.0.0
+      # Storage
+      MEDIA_ROOT: /media
+      UPLOAD_DIR: /media/uploads
+      VIDEO_DIR: /media/videos
+      AUDIT_DIR: /media/audit
+      # Security
+      HMAC_SECRET: dev-hmac-secret-change-in-prod
+      TOKEN_EXPIRY_SECONDS: 300
+      # Redis — use service name, NOT localhost
+      REDIS_HOST: redis
+      REDIS_PORT: 6379
+      REDIS_DB: 0
+      # Transcoding
+      TRANSCODE_ENABLED: "true"
+      FFMPEG_THREADS: 0
+      RENDITIONS: 240p,360p,480p,720p,1080p
+      # Observability
+      METRICS_ENABLED: "true"
+      LOG_LEVEL: info
+    volumes:
+      - media-storage:/media
+    depends_on:
+      redis:
+        condition: service_healthy
+    healthcheck:
+      test:
+        [
+          "CMD",
+          "node",
+          "-e",
+          "require('http').get('http://localhost:3000/', (r) => r.statusCode === 200 ? process.exit(0) : process.exit(1)).on('error', () => process.exit(1))",
+        ]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 40s
+
+  transcode-worker:
+    build:
+      context: ./pulsevault
+      dockerfile: Dockerfile.worker
+    restart: unless-stopped
+    environment:
+      NODE_ENV: development
+      MEDIA_ROOT: /media
+      VIDEO_DIR: /media/videos
+      AUDIT_DIR: /media/audit
+      REDIS_HOST: redis
+      REDIS_PORT: 6379
+      REDIS_DB: 0
+    volumes:
+      - media-storage:/media
+    depends_on:
+      redis:
+        condition: service_healthy
+  # ── One-shot migration runner ───────────────────────────────────────────────
+
+  db-migrate:
+    build:
+      context: ./frontend
+      dockerfile: Dockerfile
+      target: builder
+    command: node_modules/.bin/prisma migrate deploy --schema=./prisma/schema.prisma
+    environment:
+      DATABASE_URL: postgresql://pulsevault:pulsevault@postgres:5432/pulsevault
+    depends_on:
+      postgres:
+        condition: service_healthy
+    restart: "no"
+  # ── Frontend ────────────────────────────────────────────────────────────────
+
+  pulsevault-frontend:
+    build:
+      context: ./frontend
+      dockerfile: Dockerfile
+    container_name: pulsevault-frontend
+    restart: unless-stopped
+    ports:
+      - "3001:3000"
+    environment:
+      NODE_ENV: development
+      # Prisma / Auth
+      DATABASE_URL: postgresql://pulsevault:pulsevault@postgres:5432/pulsevault
+      BETTER_AUTH_URL: http://localhost:3001
+      BETTER_AUTH_SECRET: dev-auth-secret-change-in-prod
+      # Backend
+      BACKEND_URL: http://pulsevault:3000
+      # Social OAuth
+      GOOGLE_CLIENT_ID: ""
+      GOOGLE_CLIENT_SECRET: ""
+      GITHUB_CLIENT_ID: ""
+      GITHUB_CLIENT_SECRET: ""
+    depends_on:
+      postgres:
+        condition: service_healthy
+      db-migrate:
+        condition: service_completed_successfully
+      pulsevault:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "-q", "http://localhost:3000/"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 40s
+
+  # ── Reverse proxy ───────────────────────────────────────────────────────────
+
+  nginx:
+    image: nginx:alpine
+    container_name: pulsevault-nginx
+    restart: unless-stopped
+    ports:
+      - "8080:80"
+    volumes:
+      - ./nginx/nginx.conf:/etc/nginx/nginx.conf:ro
+      - ./nginx/conf.d:/etc/nginx/conf.d:ro
+      - media-storage:/media:ro
+    depends_on:
+      - pulsevault
+      - pulsevault-frontend
+
+  # ── Observability (optional for dev — comment out if not needed) ────────────
+
+  prometheus:
+    image: prom/prometheus:latest
+    container_name: pulsevault-prometheus
+    restart: unless-stopped
+    ports:
+      - "9090:9090"
+    volumes:
+      - ./prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - prometheus-data:/prometheus
+    command:
+      - "--config.file=/etc/prometheus/prometheus.yml"
+      - "--storage.tsdb.path=/prometheus"
+      - "--storage.tsdb.retention.time=7d"
+
+  loki:
+    image: grafana/loki:latest
+    container_name: pulsevault-loki
+    restart: unless-stopped
+    ports:
+      - "3100:3100"
+    volumes:
+      - loki-data:/loki
+      - ./loki/loki-config.yml:/etc/loki/local-config.yaml:ro
+    command: -config.file=/etc/loki/local-config.yaml
+
+  promtail:
+    image: grafana/promtail:latest
+    container_name: pulsevault-promtail
+    restart: unless-stopped
+    volumes:
+      - ./promtail/promtail-config.yml:/etc/promtail/config.yml:ro
+      - /var/log:/var/log:ro
+      - media-storage:/media:ro
+    command: -config.file=/etc/promtail/config.yml
+    depends_on:
+      loki:
+        condition: service_started
+
+volumes:
+  postgres-data:
+  redis-data:
+  media-storage:
+  prometheus-data:
+  loki-data:
+
+networks:
+  default:
+    name: pulsevault-dev-network

--- a/frontend/lib/actions/video-actions.ts
+++ b/frontend/lib/actions/video-actions.ts
@@ -21,9 +21,10 @@ export async function generateUploadQRCode() {
   // Get backend URL from environment or use default
   const backendUrl = process.env.BACKEND_URL || "http://pulsevault:3000";
   const serverUrl = process.env.BETTER_AUTH_URL || "http://localhost:8080";
+  const duration = 180;
 
   // Call backend to generate QR code with draftId
-  const response = await fetch(`${backendUrl}/qr/deeplink?userId=${session.user.id}&draftId=${draftId}&server=${encodeURIComponent(serverUrl)}`, {
+  const response = await fetch(`${backendUrl}/qr/deeplink?userId=${session.user.id}&draftId=${draftId}&server=${encodeURIComponent(serverUrl)}&duration=${duration}`, {
     method: "GET",
   });
 

--- a/pulsevault/routes/qr.js
+++ b/pulsevault/routes/qr.js
@@ -180,7 +180,8 @@ module.exports = async function (fastify, opts) {
           oneTimeUse: { type: 'boolean', default: false },
           externalApp: { type: 'string' },
           externalUserEmail: { type: 'string' },
-          externalUserId: { type: 'string' }
+          externalUserId: { type: 'string' },
+          duration: { type: 'number', default: 180 }
         }
       }
     }
@@ -194,7 +195,8 @@ module.exports = async function (fastify, opts) {
       oneTimeUse = false,
       externalApp,
       externalUserEmail,
-      externalUserId
+      externalUserId,
+      duration = 180
     } = request.query
     
     // Get server URL from query, config, or request
@@ -245,6 +247,7 @@ module.exports = async function (fastify, opts) {
     if (draftId) {
       params.set('draftId', draftId)
     }
+    params.set('duration', duration)
     
     const deeplinkUrl = `pulsecam://?${params.toString()}`
     
@@ -262,6 +265,7 @@ module.exports = async function (fastify, opts) {
       externalApp: externalApp || null,
       externalUserEmail: externalUserEmail || null,
       externalUserId: externalUserId || null,
+      duration,
       // QR code data (can be used with any QR code library)
       qrData: deeplinkUrl
     }


### PR DESCRIPTION
## Description

### QR Upload — `duration` parameter

**Demo**: 
https://youtube.com/shorts/JJxZMVX99Rs

The mobile app requires a `duration` hint when receiving an upload deeplink. This PR adds `duration=180` (seconds) as a query parameter appended to the `pulsecam://` deeplink encoded into the upload QR code.

**Changes:**
- qr.js — Added `duration` to the `/qr/deeplink` querystring schema (default `180`), appended it to the `URLSearchParams` before building the deeplink URL, and included it in the JSON response.
- video-actions.ts — Passes `&duration=180` when calling the backend `/qr/deeplink` endpoint from `generateUploadQRCode()`.

**Resulting deeplink format:**
```
pulsecam://?mode=upload&server=<url>&token=<token>&draftId=<uuid>&duration=180
```

---

### Dev Docker Compose (docker-compose.dev.yml)

The existing docker-compose.yml targets production (Proxmox/LXC) and was missing **PostgreSQL** entirely. Running it locally caused Redis `ECONNREFUSED 127.0.0.1:6379` because `REDIS_HOST` defaulted to `localhost` inside the container instead of the Docker service name.

**Changes:**
- Added docker-compose.dev.yml — a self-contained local development compose file with:
  - **PostgreSQL 16** (required by frontend Prisma/Better Auth — was absent from prod compose)
  - **Redis 7** with `REDIS_HOST: redis` explicitly set on backend and worker (fixes the `ECONNREFUSED` connection error)
  - All service ports exposed locally (`5432`, `6379`, `3000`, `3001`, `8080`, `9090`, `3100`)
  - `DATABASE_URL` and `BACKEND_URL` pre-wired between services
  - Dev-safe placeholder secrets (`HMAC_SECRET`, `BETTER_AUTH_SECRET`)

**Usage:**
```bash
docker compose -f docker-compose.dev.yml up --build
```