### PR TITLE
fix: copy frontend `.env` from example in setup script

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -30,8 +30,25 @@ fi
 
 echo "✅ Prerequisites OK"
 
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+# Set up frontend .env
+cd "$SCRIPT_DIR/../frontend"
+if [ ! -f .env ]; then
+    echo ""
+    echo "Creating frontend .env file..."
+    if [ -f .example.env ]; then
+        cp .example.env .env
+        echo "✅ frontend/.env file created from .example.env"
+        echo "   ⚠️  Remember to fill in real values in frontend/.env before deploying!"
+    else
+        echo "❌ frontend/.example.env not found!"
+        exit 1
+    fi
+fi
+
 # Navigate to pulsevault directory
-cd "$(dirname "$0")/../pulsevault"
+cd "$SCRIPT_DIR/../pulsevault"
 
 # Install dependencies
 echo ""
@@ -41,7 +58,7 @@ npm install
 # Copy .env if it doesn't exist
 if [ ! -f .env ]; then
     echo ""
-    echo "Creating .env file..."
+    echo "Creating pulsevault .env file..."
     if [ -f .env.example ]; then
         cp .env.example .env
         echo "✅ .env file created from .env.example"


### PR DESCRIPTION
setup.sh was not setting up the frontend environment file, causing `docker compose build` to fail when .env was absent (the Dockerfile copies it into the image).

**Changes:**
- Added a step to `cd` into frontend and copy .example.env → `.env` if one doesn't already exist, consistent with how the pulsevault subproject env is handled
- Resolved `SCRIPT_DIR` as an absolute path at the top of the script so subsequent `cd` calls work correctly whether the script is invoked via `bash scripts/setup.sh` or setup.sh

<img width="865" height="493" alt="00-pulse-vault-env-no-copy" src="https://github.com/user-attachments/assets/5e4625c7-18f3-418b-aeb0-b500e9a3821f" />
